### PR TITLE
Add dev build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "hidden": false
   },
   "scripts": {
-    "build": "directus-extension build"
+    "build": "directus-extension build",
+    "dev": "directus-extension build --watch"
   },
   "devDependencies": {
     "@directus/extensions-sdk": "9.13.0",


### PR DESCRIPTION
Adds a build-command with automatic re-building on file-change. 

If placing the git-repo directly into `extensions/modules` and changing the build destination to `./index.js` it provides an awesome dx in combination with the auto-reload function of directus.

Also works when using a symlink from the default dest-file into your directus project.