### PR TITLE
fix(ts): add `null` to nullable columns

### DIFF
--- a/src/lib/generateTypes/ts.ts
+++ b/src/lib/generateTypes/ts.ts
@@ -57,5 +57,12 @@ function getType(field: Field, useIntersectionTypes = false) {
       field.relation.collection ? pascalCase(field.relation.collection) : "any"
     }${field.relation.type === "many" ? "[]" : ""}`;
   }
+  if (field.schema?.is_nullable) {
+    if (field.relation && useIntersectionTypes) {
+      type = `(${type}) | null`;
+    } else {
+      type += ` | null`;
+    }
+  }
   return type;
 }


### PR DESCRIPTION
Thanks for your plugin!

I did a fix to add `| null` to nullable typescript types. It should also handle `null` properly when using intersection!

fix #17