### PR TITLE
fix: typescript many relation array

### DIFF
--- a/src/lib/generateTypes/ts.ts
+++ b/src/lib/generateTypes/ts.ts
@@ -55,7 +55,11 @@ function getType(field: Field, useIntersectionTypes = false) {
   if (field.relation) {
     type += ` ${useIntersectionTypes ? "&" : "|"} ${
       field.relation.collection ? pascalCase(field.relation.collection) : "any"
-    }${field.relation.type === "many" ? "[]" : ""}`;
+    }`;
+    
+    if (field.relation.type === "many") {
+      type = `(${type})[]`;
+    }
   }
   if (field.schema?.is_nullable) {
     if (field.relation && useIntersectionTypes) {


### PR DESCRIPTION
This fix many relations arrays declaration to also take the identifier field

before:
```ts
export type TableA = {
  //...
}

export type TableB = {
  table_a: string | TableA[] // string is not an array here
}
```


after:
```ts
export type TableA = {
  //...
}

export type TableB = {
  table_a: (string | TableA)[]
}
```