### PR TITLE
Add warning message if relation meta is missing in field

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -38,6 +38,10 @@ export async function getCollections(api) {
   );
   const relations = relationsRes.data.data;
   relations.forEach((relation) => {
+    if (!relation.meta) {
+      warn(`Relation on field '${relation.field}' in collection '${relation.collection}' has no meta. Maybe missing a relation inside directus_relations table.`);
+      return;
+    }
     const oneField = collections[relation.meta.one_collection]?.fields.find(
       (field) => field.field === relation.meta.one_field
     );


### PR DESCRIPTION
Hi,
When using an already existing database and when you plug a Direction onto it, Directus seems to not fill relations in `directus_relations` table, and so the api (`/relations`) returns a `null` for the meta entry in relation object:
![image](https://github.com/maltejur/directus-extension-generate-types/assets/61592570/b84cae17-f646-403f-95d2-92d84228495b)
I don't know if it's a known issue(?), I asked on their Discord, but for now no answer, maybe I'll end up opening a new issue on github.

I just added a early return with a warning in console to indicate where to look. I was facing an error on `const oneField = collections[relation.meta.one_collection]` with an infinite loop