### PR TITLE
Update admin access check for Directus 11.0.2 compatibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ export default {
     },
   ],
   hidden: false,
-  preRegisterCheck(user) {
-    return user.admin_access;
-  },
+	preRegisterCheck(user: User & { admin_access: boolean }) {
+		return user.admin_access;
+	},
 } as ModuleConfig;

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,9 @@ export default {
     },
   ],
   hidden: false,
-	preRegisterCheck(user: User & { admin_access: boolean }) {
-		return user.admin_access;
-	},
+  preRegisterCheck(
+    user: User & { role?: { admin_access?: boolean }; admin_access?: boolean }
+  ) {
+    return user.admin_access ?? user.role?.admin_access ?? false;
+  },
 } as ModuleConfig;

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,6 @@ export default {
   ],
   hidden: false,
   preRegisterCheck(user) {
-    return user.role.admin_access;
+    return user.admin_access;
   },
 } as ModuleConfig;


### PR DESCRIPTION
This pull request updates the `preRegisterCheck` function in the Generate Types extension to be compatible with both Directus 11 and 11.0.2+. The change addresses the relocation of the `admin_access` property from the user's role to the user object itself in newer Directus versions.

Changes made:

1. Updated the type definition for the `user` parameter in `preRegisterCheck` to include both possible structures:
   - `admin_access` directly on the user object
   - `admin_access` within the `role` object

2. Modified the `preRegisterCheck` function to check for `admin_access` in both locations using the nullish coalescing operator (`??`).

3. Added a fallback to `false` if `admin_access` is not found in either location.

This change ensures backwards compatibility with older Directus versions while supporting the new structure in Directus 11.0.2 and later.

Testing:
- Tested with Directus 11.0.2
- Verified that the extension works correctly with the new user structure
- Ensured backwards compatibility with older Directus versions

Please review and test this change to ensure it meets the requirements for both new and existing Directus installations.