### PR TITLE
Consider groups optional in typescript

### DIFF
--- a/src/lib/generateTypes/ts.ts
+++ b/src/lib/generateTypes/ts.ts
@@ -76,5 +76,8 @@ function getType(field: Field, useIntersectionTypes = false) {
       type += ` | null`;
     }
   }
+  if (field.type === 'alias' && field.schema === null) {
+    type = 'string | undefined';
+  }
   return type;
 }

--- a/src/lib/generateTypes/ts.ts
+++ b/src/lib/generateTypes/ts.ts
@@ -25,6 +25,7 @@ export default async function generateTsTypes(
       ret += "  ";
       ret += field.field.includes("-") ? `"${field.field}"` : field.field;
       if (field.schema?.is_nullable) ret += "?";
+      else if (field.type === 'alias' && field.schema === null && field.meta.special.includes('group')) ret += "?";
       ret += ": ";
       ret += getType(field, useIntersectionTypes);
       ret += ";\n";
@@ -75,9 +76,6 @@ function getType(field: Field, useIntersectionTypes = false) {
     } else {
       type += ` | null`;
     }
-  }
-  if (field.type === 'alias' && field.schema === null) {
-    type = 'string | undefined';
   }
   return type;
 }


### PR DESCRIPTION
Tiny change so that field groups are not returned as required string fields (they do not contain any data and no schema, so they should be marked as optional - maybe even as `never`?)